### PR TITLE
Fix panic at TryFrom<&str>

### DIFF
--- a/src/tsid/conversions.rs
+++ b/src/tsid/conversions.rs
@@ -1,4 +1,4 @@
-use crate::tsid::{ParseErrorReason, TsidError, REVERSE, TSID};
+use crate::tsid::{ParseErrorReason, TsidError, REVERSE, TSID, ALPHABET};
 
 impl From<TSID> for u64 {
     fn from(val: TSID) -> Self {
@@ -28,7 +28,7 @@ impl TryFrom<&str> for TSID {
     type Error = TsidError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        if value.len() != 13 {
+        if value.len() != 13 || !value.chars().all(|c| ALPHABET.contains(&c)) {
             return Err(TsidError::ParseError(ParseErrorReason::InvalidLength));
         }
         let chars = value.as_bytes();

--- a/src/tsid/mod.rs
+++ b/src/tsid/mod.rs
@@ -148,4 +148,10 @@ mod tests {
         let id1 = TSID::new(496830748901259172);
         println!("{}", bson::doc! {"id": id1 })
     }
+
+    #[test]
+    fn test_regression_panic_try_from_str() {
+        // Was panicking at src/tsid/conversions.rs: invalid key
+        assert!(TSID::try_from("-------------").is_err());
+    }
 }


### PR DESCRIPTION
Parsing from `str`, there was no check if the characters were in the alphabet.

I detected this error developing my ID debug/parser CLI tool: [uuinfo](https://github.com/racum/uuinfo), that tries to parse arbitrary values to detect the ID format.

Don't forget to bump the version and publish!